### PR TITLE
Implemented reading versioned records and deletion for the Buffer through Table

### DIFF
--- a/lstore/query.py
+++ b/lstore/query.py
@@ -77,17 +77,6 @@ class Query:
                 return False
             
             return records
-
-            # Return only the projected columns
-            # result = []
-            # for record in records:
-            #     projected_columns = [
-            #         record.columns[i] if projected_columns_index[i] == 1 else None
-            #         for i in range(self.table.num_columns)
-            #     ]
-            #     result.append(Record(record.key, projected_columns))
-            
-            # return result
         except Exception:
             return False
 
@@ -102,8 +91,21 @@ class Query:
         # Returns False if record locked by TPL
         # Assume that select will never be called on a key that doesn't exist
         """
-        # TODO: Implement version control for historical record versions
-        return False
+        try:
+            # Get projected list of records
+            records = self.table.select(
+                search_key,
+                search_key_index,
+                projected_columns_index,
+                relative_version,
+            )
+
+            if not records:
+                return False
+            
+            return records
+        except Exception:
+            return False
 
     def update(self, primary_key, *columns) -> bool:
         """

--- a/lstore/query.py
+++ b/lstore/query.py
@@ -1,4 +1,4 @@
-from typing import Literal,Union
+from typing import Literal
 
 from lstore.table import Table, Record
 from lstore.index import Index
@@ -53,7 +53,7 @@ class Query:
         search_key,
         search_key_index,
         projected_columns_index: list[Literal[0, 1]]
-    ) -> Union[list[Record], bool]:
+    ) -> list[Record] | bool:
         """
         # Read matching record with specified search key
         # :param search_key: the value you want to search based on

--- a/lstore/query.py
+++ b/lstore/query.py
@@ -42,10 +42,8 @@ class Query:
         # Returns False if insert fails for whatever reason
         """
         try:
-            # Create a new Record object
-            record = Record(key=columns[self.table.key], columns=columns)
             # Insert the record into the table
-            error_code = self.table.insert(record)
+            error_code = self.table.insert(columns)
             return error_code == 0  # 0 means no error, success
         except Exception:
             return False

--- a/lstore/storage/buffer.py
+++ b/lstore/storage/buffer.py
@@ -82,6 +82,11 @@ class Buffer:
 
         :return: Populated Record with data, or None if unsuccessful
         """
-        record_indices: list[RecordIndex] = self.page_dir[rid]
-
-        return self.bufferpool.read(rid, proj_col_idx, record_indices, rel_version)
+        return self.bufferpool.read(rid, proj_col_idx, rel_version)
+    
+    def delete_record(self, rid: RID):
+        """
+        Marks record as deleted by setting base record's indirection to special
+        RID with tombstone == True
+        """
+        self.bufferpool.delete(rid)

--- a/lstore/storage/buffer.py
+++ b/lstore/storage/buffer.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 # TODO: For LRU cache, but large memory footprint
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict
 
 from lstore.storage.bufferpool import Bufferpool
 from lstore.storage.record_index import RecordIndex
@@ -9,8 +9,6 @@ from lstore.storage.disk import Disk
 from lstore.storage.rid import RID, rid_generator
 
 from lstore.storage.record import Record
-from lstore.storage.meta_col import MetaCol
-from lstore.page import Page
 
 class Buffer:
     """
@@ -50,7 +48,8 @@ class Buffer:
         self,
         rid: RID,
         proj_col_idx: list[Literal[0, 1]],
+        rel_version: int
     ) -> Record | None:
         record_indices = self.page_dir[rid]
 
-        return self.bufferpool.read(rid, proj_col_idx, record_indices)
+        return self.bufferpool.read(rid, proj_col_idx, record_indices, rel_version)

--- a/lstore/storage/bufferpool.py
+++ b/lstore/storage/bufferpool.py
@@ -1,4 +1,14 @@
+"""
+The bufferpool contains the actual pages in memory. The data itself is to be
+accessed via composite RecordIndex objects that encode page ids and data
+offsets.
+"""
+
+from typing import Literal
+
 import time
+
+# TODO: For LRU page cache, but large memory footprint
 from collections import OrderedDict
 
 from lstore.storage.record import Record
@@ -15,65 +25,86 @@ class Bufferpool:
     """
     A simple bufferpool that uses a hash table to store pages in memory,
     using RIDs (Record IDs) as keys.
+
+    :param table: Reference to parent table for things like num_columns
     """
 
     def __init__(self, table):
         self.table = table
 
-        self.total_columns: int = MetaCol.COL_COUNT + self.table.num_columns
+        self.total_columns = MetaCol.COL_COUNT + self.table.num_columns
 
-        self.curr_page_id: int = 0  # Total pages created in memory
-        self.page_count: int = 0    # Current number of pages
-        self.max_buffer_size: int = config.MAX_BUFFER_SIZE
+        self.curr_page_id = 0  # Total pages created in memory
+        self.page_count = 0    # Current number of pages
+        self.max_buffer_size = config.MAX_BUFFER_SIZE
 
         # Maps page id -> page for each column (including metadata)
         self.pages = [
             OrderedDict() for _ in range(self.total_columns)
         ]
 
-    def write(self, rid: RID, columns) -> list[RecordIndex]:
+    def write(self, rid: RID, columns: tuple[int]) -> list[RecordIndex]:
         """
         Writes a new record with the given data columns.
 
         Returns a list of RecordIndex objects to be used as values in the
         page directory.
+
+        :param rid: New RID for base record to be stored in page dir as key
+        :param columns: Tuple of data values for each column
+
+        :return: List of composite RecordIndices to store as val in page dir
         """
-        record_indices = []
+        record_indices = [None for _ in range(self.total_columns)]
 
         # Write metadata, saving record indices per column
-        record_indices.append(self._write_val(MetaCol.INDIR, rid))
-        record_indices.append(self._write_val(MetaCol.RID, rid))
-        record_indices.append(self._write_val(MetaCol.TIMESTAMP, time.now()))
-        record_indices.append(self._write_val(MetaCol.SCHEMA, 0))
+        record_indices[MetaCol.INDIR] = self._write_val(MetaCol.INDIR, rid)
+        record_indices[MetaCol.RID] = self._write_val(MetaCol.RID, rid)
+        record_indices[MetaCol.TIMESTAMP] = self._write_val(
+            MetaCol.TIMESTAMP, time.now())
+        record_indices[MetaCol.SCHEMA] = self._write_val(MetaCol.SCHEMA, 0)
 
         # Write data, saving record indices per remaining columns
         for i in range(MetaCol.COL_COUNT, self.total_columns):
-            record_indices.append(self._write_val(i, columns[i]))
+            record_indices[i] = self._write_val(i, columns[i])
 
         # Return indices to be stored as values in page directory
         return record_indices
 
-    def update(self, rid, tail_rid, columns):
-        tail_indices = []
+    def update(self, rid: RID, tail_rid: RID, columns: tuple[int | None]):
+        """
+        'Updates' a record by creating a new tail record.
+
+        The indirection pointer of the base record and previous newest tail
+        record are changed accordingly. The schema encoding of the base
+        record is also updated to reflect which columns have ever been
+        updated.
+
+        :param rid: Base record RID
+        :param tail_rid: New tail record RID registered in page dir
+        :param columns: New data values. Vals are none if no update for that col
+        """
+        tail_indices = [None for _ in range(self.total_columns)]
 
         # Indirection -----------------
 
         # Set new tail indir to prev tail rid and base indir to new rid
         base_indices = self.table.buffer.page_dir[rid]
-        prev_rid = self._read_page(
+        prev_rid = self._read_val(
             MetaCol.INDIR, base_indices[MetaCol.INDIR]
         )
-        tail_indices.append(self._write_val(MetaCol.INDIR, prev_rid))
+        tail_indices[MetaCol.INDIR] = self._write_val(MetaCol.INDIR, prev_rid)
         self._overwrite_val(rid, MetaCol.INDIR, tail_rid)
 
         # RID & Timestamp -------------
 
-        tail_indices.append(self._write_val(MetaCol.RID, tail_rid))
-        tail_indices.append(self._write_val(MetaCol.TIMESTAMP, time.now()))
+        tail_indices[MetaCol.RID] = self._write_val(MetaCol.RID, tail_rid)
+        tail_indices[MetaCol.TIMESTAMP] = self._write_val(
+            MetaCol.TIMESTAMP, time.now())
 
         # Schema encoding & data ------
 
-        schema_encoding = self._read_page(
+        schema_encoding = self._read_val(
             MetaCol.SCHEMA, base_indices[MetaCol.SCHEMA]
         )
 
@@ -90,12 +121,13 @@ class Bufferpool:
                 schema_encoding = schema_encoding | (1 << data_col)
             elif config.CUMULATIVE_UPDATE:
                 # Get previous value if cumulative
-                val = self._read_page(real_col, prev_indices[real_col])
+                val = self._read_val(real_col, prev_indices[real_col])
 
-            tail_indices.append(self._write_val(real_col, val))
+            tail_indices[real_col] = self._write_val(real_col, val)
 
         # Write both base and new tail record schema encoding
-        tail_indices.append(self._write_val(MetaCol.SCHEMA, schema_encoding))
+        tail_indices[MetaCol.SCHEMA] = self._write_val(
+            MetaCol.SCHEMA, schema_encoding)
         self._overwrite_val(rid, MetaCol.SCHEMA, schema_encoding)
 
         return tail_indices
@@ -103,11 +135,22 @@ class Bufferpool:
     def read(
         self,
         rid: RID,
-        proj_col_idx,
-        record_indices,
-        rel_version: int | None
+        proj_col_idx: list[Literal[0, 1]],
+        record_indices: list[RecordIndex],
+        rel_version: int
     ) -> Record:
-        schema_encoding = self._read_page(
+        """
+        Reads a record (projected columns only) given an RID and its associated
+        RecordIndex found in the page directory.
+
+        :param rid: Base record RID
+        :param proj_col_idx: List of 0s or 1s indicating which columns to return
+        :param record_indices: List of RecordIndex for the base record
+        :param rel_version: Relative version to return. 0 is newest, -<n> is old
+
+        :return: Record with retrieved data in record.columns and base rid
+        """
+        schema_encoding = self._read_val(
             MetaCol.SCHEMA, record_indices[MetaCol.SCHEMA])
 
         # If a column has tail records, get record indices for correct version
@@ -126,13 +169,13 @@ class Bufferpool:
 
         columns = []
         for col_idx, r_idx in data_indices:
-            columns.append(self._read_page(col_idx + MetaCol.COL_COUNT, r_idx))
+            columns.append(self._read_val(col_idx + MetaCol.COL_COUNT, r_idx))
 
         return Record(self.table.key, columns, rid)
 
     # Helpers ------------------------
 
-    def _write_val(self, col, val) -> RecordIndex:
+    def _write_val(self, col: int, val: int) -> RecordIndex:
         """
         Writes the given value to the last page in the given column.
 
@@ -152,8 +195,8 @@ class Bufferpool:
             self.curr_page_id += 1
             self.page_count += 1
 
+            # TODO: handle full buffer
             if self.max_buffer_size and self.page_count > self.max_buffer_size:
-                # TODO: handle full buffer
                 # self.page_count -= 1
                 raise NotImplementedError(
                     "Max buffer size specified, but not implemented yet")
@@ -162,12 +205,15 @@ class Bufferpool:
 
         return RecordIndex(page.id, offset)
 
-    def _overwrite_val(self, rid, col, val):
+    def _overwrite_val(self, rid: RID, col: int, val: int):
+        """
+        Overwrites a value in a page.
+        """
         r_idx: RecordIndex = self.table.buffer.page_dir[rid][col]
 
         self.pages[col][r_idx.page_id].update(val, r_idx.offset)
 
-    def _read_page(self, col: int, r_idx: RecordIndex):
+    def _read_val(self, col: int, r_idx: RecordIndex):
         """
         Reads a value from a page given a column (including metadata cols)
         and a RecordIndex.
@@ -183,16 +229,15 @@ class Bufferpool:
         if not config.CUMULATIVE_UPDATE:
             raise NotImplementedError(
                 "Noncumulative update not finished, set config.CUMULATIVE_UPDATE to True")
-        
+
         # Will do it at least once since version 0 is newest tail record
         while rel_version <= 0:
             # Get previous tail record (or base record). base.indir == base.rid!
-            rid = self._read_page(
+            rid = self._read_val(
                 MetaCol.INDIR, record_indices[MetaCol.INDIR])
-            
+
             record_indices = self.page_dir[rid]
 
             rel_version += 1
-        
+
         return record_indices
-    

--- a/lstore/storage/meta_col.py
+++ b/lstore/storage/meta_col.py
@@ -3,7 +3,7 @@ from enum import Enum
 class MetaCol(Enum):
     INDIR = 0      # Base: RID of latest tail; Tail: RID of prev
     RID = 1        # Record ID (and index/location/hashable in page directory)
-    TIMESTAMP = 2  # Timestamp for both base and tail record
+    TIME = 2       # Timestamp for both base and tail record
     SCHEMA = 3     # Bits representing cols, 1s where updated
 
     COL_COUNT = 4  # Number of metadata columns

--- a/lstore/storage/rid.py
+++ b/lstore/storage/rid.py
@@ -11,26 +11,25 @@ from collections import namedtuple
 import time
 
 """
-Create an RID 'class' (not instance) as a named tuple.
+Create an RID namedtuple.
 
 This offers the benefits of classes with less overhead. Importantly, named
-tuples are hashable and can be used.
+tuples are hashable and can be used to clearly demarcate location in
+physical memory.
 """
-RID = namedtuple("RID", ["timestamp", "volume_id", "page_id", "offset"])
+RID = namedtuple("RID", ["timestamp", "tombstone", "volume_id"])
+
+DEAD_RECORD_RID = RID(0.0, True, 0)
 
 
 def rid_generator() -> Generator[RID, None, None]:
     """
     Generates an RID;
-    
+
     TODO: Currently DOES NOT reflect physical location and will NOT be unique
     following closing of database; ie should be made to support persistence.
     """
     volume_id = 0
-    page_id = 0
-    offset = 0
 
     while True:
-        yield RID(time.time(), volume_id, page_id, offset)
-        page_id += 1
-        offset += 1
+        yield RID(time.time(), False, volume_id)

--- a/lstore/table.py
+++ b/lstore/table.py
@@ -85,12 +85,11 @@ class Table:
         result = []
         for rid in rid_list:
             try:
-                record: Record = self.buffer.get_record(
-                    rid, proj_col_idx, rel_version)
-            except KeyError as e:
+                result.append(
+                    self.buffer.get_record(rid, proj_col_idx, rel_version)
+                )
+            except Exception as e:
                 print(f"Failed to find rid={rid}")
-
-            result.append(record)
 
         return result
 
@@ -111,10 +110,7 @@ class Table:
 
         :param rid: RID of record to 'delete'
         """
-        page = self.buffer.get_page(rid)
-        if page:
-            page.invalidate(rid)
-            self.buffer.add_page(rid, page)
+        self.buffer.delete(rid)
 
     def __del__(self):
         """

--- a/lstore/table.py
+++ b/lstore/table.py
@@ -3,6 +3,8 @@ from typing import Literal
 from lstore.index import Index
 from lstore.storage.buffer import Buffer
 from lstore.storage.record import Record
+
+
 class Table:
     """
     :param name:         # Table name
@@ -52,7 +54,13 @@ class Table:
 
         return 0
 
-    def select(self, search_key, search_key_idx, proj_col_idx: list[Literal[0, 1]]) -> list[Record]:
+    def select(
+        self,
+        search_key,
+        search_key_idx,
+        proj_col_idx: list[Literal[0, 1]],
+        rel_version: int = 0
+    ) -> list[Record]:
         """
         Select records based on the primary key. Use the index for fast lookup.
         """
@@ -62,7 +70,7 @@ class Table:
         result = []
         for rid in rid_list:
             try:
-                record: Record = self.buffer.get_record(rid, proj_col_idx)
+                record: Record = self.buffer.get_record(rid, proj_col_idx, rel_version)
             except KeyError as e:
                 print(f"Failed to find rid={rid}")
 

--- a/lstore/table.py
+++ b/lstore/table.py
@@ -1,12 +1,21 @@
+"""
+Tables in the database. Contains important descriptive attributes such as the
+index of the primary key and number of data columns. Also manages in-memory
+buffer and indices for performant querying.
+"""
+
 from typing import Literal
 
 from lstore.index import Index
 from lstore.storage.buffer import Buffer
 from lstore.storage.record import Record
+from lstore.storage.rid import RID
 
 
 class Table:
     """
+    Database table with buffer and query indices.
+
     :param name:         # Table name
     :param num_columns:  # Number of DATA columns (all columns are integer)
     :param key:          # Index of table key in columns (ie primary key, ex 2 if 3rd col)
@@ -29,25 +38,24 @@ class Table:
     def __merge(self):
         print("merge is happening")
 
-    def insert(self, record: Record) -> int:
+    def insert(self, columns: tuple[int]) -> int:
         """
-        Given a new Record with a key and columns filled, attempts to insert
-        the record through the page directory and populates the RID field.
+        Inserts a new record with the given data in columns.
 
-        Returns an error code as an integer:
-            0: No error
-            1: Unspecified error
+        Returns an error code if things went wrong.
+
+        :param columns: New data values
         """
         try:
-            # Insert a record, directory will return its new RID value
-            record.rid = self.buffer.insert_record(record)
+            # Insert a record, buffer will return its new RID
+            rid = self.buffer.insert_record(columns)
         except Exception as e:
             # This catch-all error should be last
-            print(f"Error inserting record '{record.key}'")
+            print(f"Error inserting record '{self.key}'")
             return 1
 
         # Update primary key's index
-        self.index.insert_val(self.key, record.columns[self.key], record.rid)
+        self.index.insert_val(self.key, columns[self.key], rid)
 
         # TODO: Update other indices
         pass
@@ -56,13 +64,20 @@ class Table:
 
     def select(
         self,
-        search_key,
-        search_key_idx,
+        search_key: int,
+        search_key_idx: int,
         proj_col_idx: list[Literal[0, 1]],
         rel_version: int = 0
     ) -> list[Record]:
         """
         Select records based on the primary key. Use the index for fast lookup.
+
+        :param search_key: Value to search on in index column
+        :param search_key_idx: Index of column to search
+        :param proj_col_idx: Data column indices that will be returned
+        :param rel_version: Relative record version. 0 is newest, -<n> is older
+
+        :return: A list of Records for each projected column
         """
         # Get rid (point query) or rids (range query) via index
         rid_list = self.index.locate(search_key_idx, search_key)
@@ -70,7 +85,8 @@ class Table:
         result = []
         for rid in rid_list:
             try:
-                record: Record = self.buffer.get_record(rid, proj_col_idx, rel_version)
+                record: Record = self.buffer.get_record(
+                    rid, proj_col_idx, rel_version)
             except KeyError as e:
                 print(f"Failed to find rid={rid}")
 
@@ -78,17 +94,22 @@ class Table:
 
         return result
 
-    def update(self, rid, columns):
+    def update(self, rid: RID, columns: tuple[int]):
         """
         Updates the record with the given RID. This updates the base record's
         schema encoding and indirection pointer to point to the latest tail
         record, but does not alter its data.
+
+        :param rid: RID of base record to update
+        :param columns: New data values
         """
         self.buffer.update_record(rid, columns)
 
-    def delete(self, rid):
+    def delete(self, rid: RID):
         """
-        Deletes the record with the given RID by marking it invalid in the bufferpool.
+        Deletes the record with the given RID by marking it invalid
+
+        :param rid: RID of record to 'delete'
         """
         page = self.buffer.get_page(rid)
         if page:


### PR DESCRIPTION
Query's select_version and delete methods should now be supported by Table.

Also added a lot of documentation to table.py, buffer.py, and bufferpool.py. Various other minor changes as well.