### PR TITLE
Pulled range query logic for Dict out of query.py, table.py, and inde…

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -46,7 +46,7 @@ for i in range(0, 10000, 100):
     end_value = start_value + 100
     result = query.sum(start_value, end_value - 1, randrange(0, 5))
 agg_time_1 = process_time()
-print("Aggregate 10k of 100 record batch took:\t", agg_time_1 - agg_time_0)
+print("Aggregate 10k of 100 record batch took:\t\t", agg_time_1 - agg_time_0)
 
 # Measuring Delete Performance
 delete_time_0 = process_time()

--- a/lstore/index.py
+++ b/lstore/index.py
@@ -45,8 +45,7 @@ class Index:
 
         # Collect all RIDs for values within the specified range
         result = []
-        for value in range(begin, end + 1):  # Assuming integer range for simplicity
-            result.extend(self.indices[column].get(value))
+        result.extend(self.indices[column].get_range(begin, end))
         return result
 
     def create_index(self, column_number):

--- a/lstore/index_types/bptree.py
+++ b/lstore/index_types/bptree.py
@@ -153,7 +153,7 @@ class BPTree:
        #print(f'Key:{key_search} not found in leaf node')
         return False # If the key/value pair is not found
     
-    def range_query_tree(self, key_low, key_high):
+    def get_range(self, key_low, key_high):
         """
         Performs range query on tree returns list of values
         """
@@ -190,7 +190,7 @@ class BPTreeIndex(IndexType):
             return values
         
     def get_range(self, begin, end):
-        results = self.tree.range_query_tree(begin, end)
+        results = self.tree.get_range(begin, end)
         # Will need to flatten results, becuase could have buckets in BPTree
         # i.e. multiple values per key
         flattened_results = [val for sublist in results for val in sublist]

--- a/lstore/index_types/dict_index.py
+++ b/lstore/index_types/dict_index.py
@@ -14,8 +14,16 @@ class DictIndex(IndexType):
         
         return [output]
 
-    def get_range(self, begin, end):
-        raise NotImplementedError()
+    def get_range(self, begin, end) -> list[RID]:
+        """
+            Takes in a begin key and end key
+            Returns list of RIDs of all keys inbetween
+        """ 
+        output = []
+        for val in range(begin, end + 1):
+            output.append(self.data.get(val, None))
+        
+        return output
 
     def insert(self, val, rid):
         self.data[val] = rid

--- a/lstore/index_types/index_config.py
+++ b/lstore/index_types/index_config.py
@@ -5,6 +5,8 @@ from lstore.index_types.index_type import IndexType
 
 from lstore.index_types.bptree import BPTreeIndex
 
+from lstore.index_types.dict_index import DictIndex
+
 class IndexConfig:
     """
     index_type: Two options, for now: 1) BPTreeIndex 2) DictIndex (hash)

--- a/lstore/table.py
+++ b/lstore/table.py
@@ -98,6 +98,27 @@ class Table:
                 print(f"Failed to find rid={rid}")
 
         return records
+    
+    def select_range(
+        self,
+        start_range: int,
+        end_range: int,
+        search_key_idx: int,
+        proj_col_idx: list[Literal[0, 1]],
+        rel_version: int = 0  # Default to newest tail (lastest version)
+    ) -> list[Record]:
+        rid_list = self.index.locate_range(start_range, end_range, search_key_idx)
+        records = []
+        for rid in rid_list:
+            try:
+                records.append(
+                    self.buffer.get_record(rid, proj_col_idx, rel_version)
+                )
+            except Exception as e:
+                print(f"Failed to find rid={rid}")
+
+        return records
+
 
     def update(self, rid: RID, columns: tuple[int]):
         """


### PR DESCRIPTION
This branch allows use of the bptree range query, where before single searches were hardcoded into the summation function

Generalizes so any index_type can control what their range query does and how it does it. 