### PR TITLE
Eric/feature: Implemented more granular locking in bufferpool

### DIFF
--- a/lstore/query.py
+++ b/lstore/query.py
@@ -176,9 +176,6 @@ class Query:
                 relative_version,
             )
 
-            if not records:
-                return False
-
             return records
         except Exception as e:
             self._print_error(e)
@@ -193,9 +190,6 @@ class Query:
                 projected_columns_index,
                 relative_version
             )
-
-            if not records:
-                return False
             
             return records
         except Exception as e:

--- a/lstore/storage/buffer/bufferpool.py
+++ b/lstore/storage/buffer/bufferpool.py
@@ -293,18 +293,17 @@ class Bufferpool:
             if pages is None:
                 pages = self.page_table.init_pages(pages_id)
 
-        with pages.lock:
-            # Get page (from disk if necessary)
-            page = pages[col]
-            if page is None:
-                page = self._get_page_from_disk(pages, pages_id, col)
-            
-            pages.offset = page.offset
+        # Get page (from disk if necessary)
+        page = pages[col]
+        if page is None:
+            page = self._get_page_from_disk(pages, pages_id, col)
+        
+        pages.offset = page.offset
 
-            page = self._update_evict_queue(page, pages_id, col)
+        self._update_evict_queue(pages_id, col)
 
-            page.update(val, offset)
-            page.is_dirty = True
+        page.update(val, offset)
+        page.is_dirty = True
 
     def _read_val(self, col: int, pages_id: int, offset: int):
         """
@@ -316,17 +315,16 @@ class Bufferpool:
         if pages is None:
             pages = self.page_table.init_pages(pages_id)
 
-        with pages.lock:
-            # Get page (from disk if necessary)
-            page = pages[col]
-            if page is None:
-                page = self._get_page_from_disk(pages, pages_id, col)
+        # Get page (from disk if necessary)
+        page = pages[col]
+        if page is None:
+            page = self._get_page_from_disk(pages, pages_id, col)
 
-            pages.offset = page.offset
+        pages.offset = page.offset
 
-            self._update_evict_queue(pages_id, col)
+        self._update_evict_queue(pages_id, col)
 
-            return page.read(offset)
+        return page.read(offset)
         
     def _get_page_from_disk(self, pages: PageTableEntry, pages_id: int, col: int):
         """

--- a/lstore/storage/buffer/bufferpool.py
+++ b/lstore/storage/buffer/bufferpool.py
@@ -291,13 +291,15 @@ class Bufferpool:
         if pages is None:
             pages = self.page_table.get_entry(pages_id)
             if pages is None:
-                pages = self.page_table.init_pages(pages_id, page.offset)
+                pages = self.page_table.init_pages(pages_id)
 
         with pages.lock:
             # Get page (from disk if necessary)
             page = pages[col]
             if page is None:
                 page = self._get_page_from_disk(pages, pages_id, col)
+            
+            pages.offset = page.offset
 
             page = self._update_evict_queue(page, pages_id, col)
 
@@ -312,13 +314,15 @@ class Bufferpool:
         # Get page entry (create empty one if needed)
         pages = self.page_table.get_entry(pages_id)
         if pages is None:
-            pages = self.page_table.init_pages(pages_id, page.offset)
+            pages = self.page_table.init_pages(pages_id)
 
         with pages.lock:
             # Get page (from disk if necessary)
             page = pages[col]
             if page is None:
                 page = self._get_page_from_disk(pages, pages_id, col)
+
+            pages.offset = page.offset
 
             self._update_evict_queue(pages_id, col)
 

--- a/lstore/storage/buffer/merge_mgr.py
+++ b/lstore/storage/buffer/merge_mgr.py
@@ -124,7 +124,7 @@ class MergeManager:
 
         for page_id in page_ids:
             # Get all pages associated with page id
-            pages = page_table.get_page_entry(page_id)
+            pages = page_table.get_entry(page_id)
             with pages:
                 for col in range(tcols):
                     if pages[col] is None:

--- a/lstore/storage/buffer/merge_mgr.py
+++ b/lstore/storage/buffer/merge_mgr.py
@@ -124,12 +124,11 @@ class MergeManager:
 
         for page_id in page_ids:
             # Get all pages associated with page id
-            pages = []
-            for col in range(tcols):
-                page: Page = page_table.get_page(page_id, col)
-                if page is None:
-                    page = disk.get_page(page_id, col)
-                pages.append(page)
+            pages = page_table.get_page_entry(page_id)
+            with pages:
+                for col in range(tcols):
+                    if pages[col] is None:
+                        pages[col] = disk.get_page(page_id, col)
 
             # Get all rids in page
             rid_page = pages[MetaCol.RID]

--- a/lstore/storage/buffer/page_table.py
+++ b/lstore/storage/buffer/page_table.py
@@ -33,15 +33,6 @@ class PageTableEntry:
 
         self.lock = threading.Lock()
 
-    def __enter__(self):
-        """Context mgr entry for concurrency."""
-        self.lock.acquire()
-        return self
-
-    def __exit__(self, exc_type, exc_val, traceback):
-        """Context mgr exit for concurrency."""
-        self.lock.release()
-    
     def __getitem__(self, index: int) -> Page:
         return self.pages[index]
     

--- a/lstore/storage/buffer/page_table.py
+++ b/lstore/storage/buffer/page_table.py
@@ -120,12 +120,12 @@ class PageTable:
 
         return self.ptable[pages_id]
     
-    def get_page_entry(self, pages_id) -> PageTableEntry:
+    def get_entry(self, pages_id) -> PageTableEntry:
         return self.ptable.get(pages_id, None)
     
     def remove_page(self, pages_id, col) -> bool:
         if pages_id in self.ptable:
-            pages = self.get_page_entry(pages_id)
+            pages = self.get_entry(pages_id)
             is_entry_empty = pages.delete_page(col)
 
             if is_entry_empty:

--- a/lstore/storage/buffer/page_table.py
+++ b/lstore/storage/buffer/page_table.py
@@ -1,3 +1,11 @@
+"""
+Holds pages in memory.
+
+The PageTable is a wrapper around a dictionary of PageTableEntries, which are
+themselves wrappers around lists of pages per column.
+"""
+
+import threading
 from collections import OrderedDict
 
 from lstore import config
@@ -7,10 +15,11 @@ from lstore.storage.uid_gen import UIDGenerator
 from lstore.storage.rid import RID
 
 class PageTableEntry:
+    # Cache config params
     record_size = config.RECORD_SIZE
     page_size = config.PAGE_SIZE
 
-    def __init__(self, pages_id, total_cols, offset=None) -> None:
+    def __init__(self, pages_id: int, total_cols: int, offset=None) -> None:
         self.pages = [None for _ in range(total_cols)]
 
         self.pages_id = pages_id
@@ -18,47 +27,55 @@ class PageTableEntry:
 
         self.page_count = 0
         
+        # Offset in bytes, ie how many bytes are occupied by each page
         self.offset = PageTableEntry.record_size if offset is None else offset
 
-    def create_new_pages(self, pages_id):
-        self.pages = [Page(pages_id) for _ in range(self.total_cols)]
-        self.page_count = self.total_cols
+        self.lock = threading.Lock()
 
-    def add_page(self, page, col):
-        self[col] = page
-        self.page_count += 1
+    def __enter__(self):
+        """Context mgr entry for concurrency."""
+        self.lock.acquire()
+        return self
 
-    def get_loc(self):
-        return self.pages_id, self.offset
-
-    def __getitem__(self, index):
+    def __exit__(self, exc_type, exc_val, traceback):
+        """Context mgr exit for concurrency."""
+        self.lock.release()
+    
+    def __getitem__(self, index: int) -> Page:
         return self.pages[index]
     
-    def __setitem__(self, index, value):
+    def __setitem__(self, index: int, value: Page | None):
         self.pages[index] = value
 
     def __len__(self):
         return len(self.pages)
     
-    def has_capacity(self):
+    def create_new_pages(self, pages_id: int):
+        self.pages = [Page(pages_id) for _ in range(self.total_cols)]
+        self.page_count = self.total_cols
+
+    def add_page(self, page: Page, col: int):
+        self[col] = page
+        self.page_count += 1
+
+    def get_loc(self) -> tuple[int, int]:
+        return self.pages_id, self.offset
+    
+    def has_capacity(self) -> bool:
         return self.offset + PageTableEntry.record_size <= PageTableEntry.page_size
     
-    def write_vals(self, cols):
+    def write_vals(self, columns):
         for col, page in enumerate(self.pages):
-            page.write(cols[col])
+            page.write(columns[col])
             page.is_dirty = True
 
         self.offset += PageTableEntry.record_size
 
-    def delete_page(self, col):
+    def delete_page(self, col: int) -> bool:
         self.pages[col] = None
-
-        # Update size and delete entry if empty
         self.page_count -= 1
-        if self.page_count <= 0:
-            return True
-        
-        return False
+
+        return self.page_count <= 0
 
 class PageTable:
     base_id_gen = None
@@ -84,7 +101,7 @@ class PageTable:
     def __getitem__(self, key):
         return self.ptable[key]
     
-    def create_pages(self, is_base):
+    def create_pages(self, is_base) -> tuple[PageTableEntry, int]:
         # Assign even or odd pages_id based on base/tail record
         if is_base:
             pages_id = PageTable.base_id_gen.next_uid()      # Even
@@ -101,7 +118,7 @@ class PageTable:
 
         return pages, pages_id
     
-    def init_pages(self, pages_id, offset):
+    def init_pages(self, pages_id, offset) -> PageTableEntry:
         # Create page entry with no pages (filled with None)
         page_entry = PageTableEntry(pages_id, self.tcols, offset=offset)
 
@@ -109,19 +126,13 @@ class PageTable:
 
         return self.ptable[pages_id]
     
-    def get_page_entry(self, pages_id):
+    def get_page_entry(self, pages_id) -> PageTableEntry:
         return self.ptable.get(pages_id, None)
-
-    def get_page(self, pages_id, col):
-        page_entry = self.ptable.get(pages_id)
-        if page_entry:
-            return page_entry[col]
-            
-        return None
     
-    def remove_page(self, pages_id, col):
+    def remove_page(self, pages_id, col) -> bool:
         if pages_id in self.ptable:
-            is_entry_empty = self.ptable[pages_id].delete_page(col)
+            pages = self.get_page_entry(pages_id)
+            is_entry_empty = pages.delete_page(col)
 
             if is_entry_empty:
                 self.ptable.pop(pages_id, None)

--- a/lstore/storage/buffer/page_table.py
+++ b/lstore/storage/buffer/page_table.py
@@ -29,7 +29,7 @@ class PageTableEntry:
         self.page_count = 0
         
         # Offset in bytes, ie how many bytes are occupied by each page
-        self.offset = PageTableEntry.record_size if offset is None else offset
+        self.offset = Page.header_size
 
         self.lock = threading.Lock()
 
@@ -112,9 +112,9 @@ class PageTable:
 
         return pages, pages_id
     
-    def init_pages(self, pages_id, offset) -> PageTableEntry:
+    def init_pages(self, pages_id) -> PageTableEntry:
         # Create page entry with no pages (filled with None)
-        page_entry = PageTableEntry(pages_id, self.tcols, offset=offset)
+        page_entry = PageTableEntry(pages_id, self.tcols)
 
         self.ptable[pages_id] = page_entry
 

--- a/tester.bat
+++ b/tester.bat
@@ -28,8 +28,10 @@ if "%Test%"=="main" (
     py .\m2_tester_part1.py > "%OutputDir%\m2_tester_part1.txt"
 ) else if "%Test%"=="22" (
     py .\m2_tester_part2.py > "%OutputDir%\m2_tester_part2.txt"
-) else if "%Test%"=="3" (
-    py .\m3_tester.py > "%OutputDir%\m3_tester.txt"
+) else if "%Test%"=="31" (
+    py .\m3_tester.py > "%OutputDir%\m3_tester_part_1.txt"
+) else if "%Test%"=="32" (
+    py .\m3_tester.py > "%OutputDir%\m3_tester_part_2.txt"
 ) else if "%Test%"=="exam1" (
     py .\exam_tester_m1.py > "%OutputDir%\exam_tester_m1.txt"
 ) else if "%Test%"=="exam21" (


### PR DESCRIPTION
While page table gets locked, it is only to get the relevant base/tail page table entries and acquire their locks.

Also formally added the fix for the return on select for non-existent records issue from M2.

A few name changes for clarity in bufferpool and page table as well.